### PR TITLE
Chore/#12/모바일뷰 스타일 조정

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.7.1",
-    "styled": "^1.0.0",
     "styled-components": "^6.1.19"
   },
   "devDependencies": {

--- a/src/components/common/Footer.Styled.js
+++ b/src/components/common/Footer.Styled.js
@@ -5,6 +5,7 @@ export const FooterBox = styled.div`
   left: 0;
   bottom: 0;
   position: absolute;
+  z-index: 2;
   justify-content: center;
   align-items: center;
   width: 100%;

--- a/src/index.css
+++ b/src/index.css
@@ -9,13 +9,11 @@ body,
   min-height: 100dvh;
   display: flex;
   justify-content: center;
-  align-items: center;
   background: #fff;
 }
 
 @font-face {
   font-family: 'Pretendard Variable';
-  /* font-weight: 45 920; */
   font-style: normal;
   font-display: swap;
   src: url('./woff2/PretendardVariable.woff2') format('woff2-variations');


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
#12 
  

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
`align-items : center;`
- 위 코드는 컨텐츠가 세로로 중앙 정렬이 되는 것인데, 모바일로 접속을 했을 때 상단 부분이 잘리는 현상이 생기기 때문에 이 코드를 삭제했더니 해결! 

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
`footerBox` 스타일에 `z-index: 2;`를 임시로 설정했습니다. (만약 고정된다면 가장 앞에 떠야 하기 때문!)

- 원래는 하단바를 position: fixed;로 고정하려 했음
- 모바일 뷰로는 정상적으로 하단바가 고정됨
- PC에서는 하단바 영역이 길게 늘어나는 문제가 발생💥

**➡️ 현재는 하단바가 내용과 함께 스크롤되도록 구현했어요!**


## 📷 ScreenShot
<!— UI 변경이 있다면 스크린샷 첨부해주세요. —>
