### PR TITLE
Feat/#59/마이페이지 데이터 연동

### DIFF
--- a/src/components/Coupon/MyCoupon.jsx
+++ b/src/components/Coupon/MyCoupon.jsx
@@ -4,7 +4,7 @@ import CafeCoupon from './CafeCoupon'
 import * as S from './styled'
 import NoData from '../common/NoData'
 
-const MyCoupon = ({ coupon }) => {
+const MyCoupon = () => {
   const [availableCouponList, setAvailableCouponList] = useState([])
 
   useEffect(() => {

--- a/src/components/FavoriteCafeList/FavoriteCafeList.jsx
+++ b/src/components/FavoriteCafeList/FavoriteCafeList.jsx
@@ -4,21 +4,67 @@ import CafeListCard from '../common/CafeListCard'
 
 const FavoriteCafeList = () => {
   const CafeList = [
-    { cafeName: '너드커피', location: '서울시 용산구 청파동2가', time: '09:00-15:00' },
-    { cafeName: '너드커피', location: '서울시 용산구 청파동2가', time: '09:00-15:00' },
-    { cafeName: '너드커피', location: '서울시 용산구 청파동2가', time: '09:00-15:00' },
-    { cafeName: '너드커피', location: '서울시 용산구 청파동2가', time: '09:00-15:00' },
-    { cafeName: '너드커피', location: '서울시 용산구 청파동2가', time: '09:00-15:00' },
-    { cafeName: '너드커피', location: '서울시 용산구 청파동2가', time: '09:00-15:00' },
-    { cafeName: '너드커피', location: '서울시 용산구 청파동2가', time: '09:00-15:00' },
-    { cafeName: '너드커피', location: '서울시 용산구 청파동2가', time: '09:00-15:00' },
+    {
+      cafeName: '너드커피',
+      location: '서울시 용산구 청파동2가',
+      time: '09:00-15:00',
+      image: 'https://i.pinimg.com/736x/86/c7/58/86c7581fb49f028ae26b947441f3656e.jpg',
+    },
+    {
+      cafeName: '너드커피',
+      location: '서울시 용산구 청파동2가',
+      time: '09:00-15:00',
+      image: 'https://i.pinimg.com/736x/31/a0/88/31a088bda3c5a64cf05a8ed7d8b3039f.jpg',
+    },
+    {
+      cafeName: '너드커피',
+      location: '서울시 용산구 청파동2가',
+      time: '09:00-15:00',
+      image: 'https://i.pinimg.com/736x/86/c7/58/86c7581fb49f028ae26b947441f3656e.jpg',
+    },
+    {
+      cafeName: '너드커피',
+      location: '서울시 용산구 청파동2가',
+      time: '09:00-15:00',
+      image: 'https://i.pinimg.com/736x/6d/3c/29/6d3c29b11645e591010cae3950c3681d.jpg',
+    },
+    {
+      cafeName: '너드커피',
+      location: '서울시 용산구 청파동2가',
+      time: '09:00-15:00',
+      image: 'https://i.pinimg.com/736x/e1/d5/88/e1d5885a67a1897e7d403221b5627510.jpg',
+    },
+    {
+      cafeName: '너드커피',
+      location: '서울시 용산구 청파동2가',
+      time: '09:00-15:00',
+      image: 'https://i.pinimg.com/736x/07/e8/1e/07e81e269c70485a299a35fe8b3b9cba.jpg',
+    },
+    {
+      cafeName: '너드커피',
+      location: '서울시 용산구 청파동2가',
+      time: '09:00-15:00',
+      image: 'https://i.pinimg.com/736x/07/33/d0/0733d09fadce6386f3378e7c456f773a.jpg',
+    },
+    {
+      cafeName: '너드커피',
+      location: '서울시 용산구 청파동2가',
+      time: '09:00-15:00',
+      image: 'https://i.pinimg.com/736x/76/2c/0a/762c0ab2efdb674933568634e44796e6.jpg',
+    },
   ]
 
   return (
     <div>
       <S.Wrapper>
         {CafeList.map((item, i) => (
-          <CafeListCard key={i} name={item.cafeName} loc={item.location} time={item.time} />
+          <CafeListCard
+            key={i}
+            name={item.cafeName}
+            loc={item.location}
+            time={item.time}
+            image={item.image}
+          />
         ))}
       </S.Wrapper>
     </div>

--- a/src/components/Home/MatrixBar.jsx
+++ b/src/components/Home/MatrixBar.jsx
@@ -8,10 +8,6 @@ import info_icon from '../../assets/icons/question_icon.svg'
 import TumblerInfo from './TumblerInfo'
 
 const MatrixBar = ({ tumblerCount, savedWater, savedTree }) => {
-  // const s = Number(stamp_count)
-  // const water = (s * 0.55).toFixed(2)
-  // const tree = (s * 0.003).toFixed(3)
-
   const [openInfo, setOpenInfo] = useState(false)
 
   return (

--- a/src/components/MyPage/MyPageBox.jsx
+++ b/src/components/MyPage/MyPageBox.jsx
@@ -3,11 +3,11 @@ import * as S from './styled'
 import coupon from '@/assets/icons/coupon-mypage.svg'
 import bookmark from '@/assets/icons/bookmark-mypage.svg'
 
-const MyPageBox = ({ type, title, value }) => {
+const MyPageBox = ({ type, title, value, onClick }) => {
   const isCoupon = type === 'coupon'
 
   return (
-    <S.Box>
+    <S.Box onClick={onClick}>
       <img src={isCoupon ? coupon : bookmark} />
       <S.BoxTitle>{title}</S.BoxTitle>
       <S.BoxValue>

--- a/src/components/MyPage/ProfileContent.jsx
+++ b/src/components/MyPage/ProfileContent.jsx
@@ -10,10 +10,10 @@ import lv4_img from '@/assets/images/lv4-profile.svg'
 import lv5_img from '@/assets/images/lv5-profile.svg'
 import share from '@/assets/icons/profile-share.svg'
 
-const ProfileContent = ({ onChangeInfo, stamp, level }) => {
+const ProfileContent = ({ onChangeInfo, nickName, level, stepsLeft, tumblerCount }) => {
   const navigate = useNavigate()
 
-  const currentLevelName = (level) => {
+  const currentLevel = (level) => {
     if (level === 1) return 'Lv.1 텀블러 뉴비'
     else if (level === 2) return 'Lv.2 텀블러 입문자'
     else if (level === 3) return 'Lv.3 텀블러 러버'
@@ -21,7 +21,7 @@ const ProfileContent = ({ onChangeInfo, stamp, level }) => {
     else if (level === 5) return 'Lv.5 텀블러 히어로'
   }
 
-  const currentLevel = currentLevelName(level)
+  const levelName = currentLevel(level)
 
   return (
     <S.ProfileContentBox>
@@ -34,13 +34,13 @@ const ProfileContent = ({ onChangeInfo, stamp, level }) => {
       {level === 3 && <S.ProfileImg src={lv3_img} />}
       {level === 4 && <S.ProfileImg src={lv4_img} />}
       {level === 5 && <S.ProfileImg src={lv5_img} />}
-      <S.ProfileName>닉네임91</S.ProfileName>
+      <S.ProfileName>{nickName}</S.ProfileName>
       <S.ProfileLevelBox>
-        <S.ProfileLevel>{currentLevel}</S.ProfileLevel>
+        <S.ProfileLevel>{levelName}</S.ProfileLevel>
         <S.QuestionIcon src={question} onClick={() => onChangeInfo(true)} />
       </S.ProfileLevelBox>
       <div>
-        <StateBar stamp={stamp} level={level} />
+        <StateBar level={level} stepsLeft={stepsLeft} tumblerCount={tumblerCount} />
       </div>
     </S.ProfileContentBox>
   )

--- a/src/components/MyPage/ProfileInfo.jsx
+++ b/src/components/MyPage/ProfileInfo.jsx
@@ -27,7 +27,7 @@ const ProfileInfo = ({
           <S.Value>{issuedCoupons}회</S.Value>
         </S.CouponCount>
       </S.CurrentCountBox>
-      <S.CafePreferenceBox>
+      <S.CafePreferenceBox onClick={() => navigate('/preference')}>
         <S.PreferenceBox>
           <S.Title>내 카페 취향</S.Title>
           <S.Arrow src={arrow} />

--- a/src/components/MyPage/ProfileInfo.jsx
+++ b/src/components/MyPage/ProfileInfo.jsx
@@ -14,6 +14,25 @@ const ProfileInfo = ({
   topPreferences,
 }) => {
   const navigate = useNavigate()
+
+  const preferenceLabels = {
+    EMOTIONAL_ATMOSPHERE: '감성/분위기',
+    STUDY_WORKSPACE: '공부/작업공간',
+    CHAT_MEETING: '수다/모임',
+    HOT_PLACE: 'HOT플레이스',
+    EVENT: '이벤트/행사',
+    SPECIALTY: '고급/스페셜티',
+    DESSERT: '디저트/케익',
+    DECAF: '디카페인',
+    SEASON_MENU: '빙수/계절메뉴',
+    BRUNCH: '브런치/식사',
+    FRANCHISE: '브랜드/프랜차이즈',
+    PET_FRIENDLY: '반려동물 가능',
+    OUTDOOR_TERRACE: '야외/테라스',
+    ECO_LOCA: '친환경/로컬',
+    UNIQUE_THEME: '이색테마/메뉴',
+  }
+
   return (
     <S.ContentContainer>
       <S.CurrentCountBox>
@@ -34,12 +53,12 @@ const ProfileInfo = ({
         </S.PreferenceBox>
         <S.PreferenceValueBox>
           {topPreferences.length > 0 ? (
-            topPreferences.map((i, item) => {
-              ;<S.TextBox key={i}>
+            topPreferences.map((item, i) => (
+              <S.TextBox key={i}>
                 <S.Check src={check} />
-                <S.PreferenceValue>{item}</S.PreferenceValue>
+                <S.PreferenceValue>{preferenceLabels[item]}</S.PreferenceValue>
               </S.TextBox>
-            })
+            ))
           ) : (
             <S.TextBox>
               <S.NoPreference>선택된 취향이 없어요</S.NoPreference>

--- a/src/components/MyPage/ProfileInfo.jsx
+++ b/src/components/MyPage/ProfileInfo.jsx
@@ -1,22 +1,30 @@
 import React from 'react'
+import { useNavigate } from 'react-router-dom'
 import * as S from './styled'
 import dotLine from '@/assets/images/dot-green-line.svg'
 import arrow from '@/assets/icons/right-arrow.svg'
 import check from '@/assets/icons/check-green.svg'
 import MyPageBox from './MyPageBox'
 
-const ProfileInfo = ({ stamp, usedCoupon, availableCoupon, favoriteCafe }) => {
+const ProfileInfo = ({
+  tumblerCount,
+  issuedCoupons,
+  availableCoupons,
+  favoriteCafes,
+  topPreferences,
+}) => {
+  const navigate = useNavigate()
   return (
     <S.ContentContainer>
       <S.CurrentCountBox>
         <S.TumblerCount>
           <S.Title>누적 텀블러 사용 횟수</S.Title>
-          <S.Value>{stamp}회</S.Value>
+          <S.Value>{tumblerCount}회</S.Value>
         </S.TumblerCount>
         <S.Line src={dotLine} />
         <S.CouponCount>
           <S.Title>누적 쿠폰 발급 횟수</S.Title>
-          <S.Value>{usedCoupon}회</S.Value>
+          <S.Value>{issuedCoupons}회</S.Value>
         </S.CouponCount>
       </S.CurrentCountBox>
       <S.CafePreferenceBox>
@@ -40,8 +48,18 @@ const ProfileInfo = ({ stamp, usedCoupon, availableCoupon, favoriteCafe }) => {
         </S.PreferenceValueBox>
       </S.CafePreferenceBox>
       <S.CouponCafeBox>
-        <MyPageBox type={'coupon'} title={'사용가능 쿠폰'} value={availableCoupon} />
-        <MyPageBox type={'bookmark'} title={'즐겨찾는 카페'} value={favoriteCafe} />
+        <MyPageBox
+          type={'coupon'}
+          title={'사용가능 쿠폰'}
+          value={availableCoupons}
+          onClick={() => navigate('/coupon')}
+        />
+        <MyPageBox
+          type={'bookmark'}
+          title={'즐겨찾는 카페'}
+          value={favoriteCafes}
+          onClick={() => navigate('/favoriteCafe')}
+        />
       </S.CouponCafeBox>
     </S.ContentContainer>
   )

--- a/src/components/MyPage/ProfileInfo.jsx
+++ b/src/components/MyPage/ProfileInfo.jsx
@@ -33,18 +33,18 @@ const ProfileInfo = ({
           <S.Arrow src={arrow} />
         </S.PreferenceBox>
         <S.PreferenceValueBox>
-          <S.TextBox>
-            <S.Check src={check} />
-            <S.PreferenceValue>감성/분위기</S.PreferenceValue>
-          </S.TextBox>
-          <S.TextBox>
-            <S.Check src={check} />
-            <S.PreferenceValue>고급/스페셜티</S.PreferenceValue>
-          </S.TextBox>
-          <S.TextBox>
-            <S.Check src={check} />
-            <S.PreferenceValue>디저트 맛집</S.PreferenceValue>
-          </S.TextBox>
+          {topPreferences.length > 0 ? (
+            topPreferences.map((i, item) => {
+              ;<S.TextBox key={i}>
+                <S.Check src={check} />
+                <S.PreferenceValue>{item}</S.PreferenceValue>
+              </S.TextBox>
+            })
+          ) : (
+            <S.TextBox>
+              <S.NoPreference>선택된 취향이 없어요</S.NoPreference>
+            </S.TextBox>
+          )}
         </S.PreferenceValueBox>
       </S.CafePreferenceBox>
       <S.CouponCafeBox>
@@ -52,7 +52,7 @@ const ProfileInfo = ({
           type={'coupon'}
           title={'사용가능 쿠폰'}
           value={availableCoupons}
-          onClick={() => navigate('/coupon')}
+          onClick={() => navigate('/coupon', { state: { tab: 'myCoupon' } })}
         />
         <MyPageBox
           type={'bookmark'}

--- a/src/components/MyPage/StateBar.jsx
+++ b/src/components/MyPage/StateBar.jsx
@@ -12,16 +12,6 @@ const StateBar = ({ level, stepsLeft, tumblerCount }) => {
 
   const stateBarWidth = widthCalculate(tumblerCount, level)
 
-  const nextLevelCount = (level) => {
-    if (level === 1) return 2
-    else if (level === 2) return 3
-    else if (level === 3) return 4
-    else if (level === 4) return 5
-    else if (level === 5) return null
-  }
-
-  const nextLevel = nextLevelCount(level)
-
   return (
     <div>
       <S.StateBarContainer>

--- a/src/components/MyPage/StateBar.jsx
+++ b/src/components/MyPage/StateBar.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import * as S from './styled'
 
-const StateBar = ({ stamp, level }) => {
+const StateBar = ({ level, stepsLeft, tumblerCount }) => {
   const widthCalculate = (stamp, level) => {
     if (level === 1) return Number((22.0625 / 4).toFixed(2)) * stamp
     else if (level === 2) return Number((22.0625 / 5).toFixed(2)) * (stamp - 5)
@@ -10,17 +10,17 @@ const StateBar = ({ stamp, level }) => {
     else if (level === 5) return 22.0625
   }
 
-  const stateBarWidth = widthCalculate(stamp, level)
+  const stateBarWidth = widthCalculate(tumblerCount, level)
 
-  const nextLevelCount = (stamp, level) => {
-    if (level === 1) return 5 - stamp
-    else if (level === 2) return 11 - stamp
-    else if (level === 3) return 21 - stamp
-    else if (level === 4) return 41 - stamp
+  const nextLevelCount = (level) => {
+    if (level === 1) return 2
+    else if (level === 2) return 3
+    else if (level === 3) return 4
+    else if (level === 4) return 5
     else if (level === 5) return null
   }
 
-  const nextLevel = nextLevelCount(stamp, level)
+  const nextLevel = nextLevelCount(level)
 
   return (
     <div>
@@ -31,7 +31,7 @@ const StateBar = ({ stamp, level }) => {
       <S.LevelTextContainer>
         <S.LevelState>{level === 5 ? 'Lv.4' : `Lv.${level}`}</S.LevelState>
         <S.NextLevel>
-          {level === 5 ? '최고 레벨 도달' : `다음 레벨까지 ${nextLevel}회 남음`}
+          {level === 5 ? '최고 레벨 도달' : `다음 레벨까지 ${stepsLeft}회 남음`}
         </S.NextLevel>
         <S.LevelState>{level === 5 ? 'Lv.5' : `Lv.${level + 1}`}</S.LevelState>
       </S.LevelTextContainer>

--- a/src/components/MyPage/styled.js
+++ b/src/components/MyPage/styled.js
@@ -219,12 +219,20 @@ export const Line = styled.img`
 
 export const PreferenceValue = styled.span`
   color: #005c4a;
-  font-family: Inter;
   font-family: 'Pretendard Variable';
   font-style: normal;
   font-weight: 500;
   line-height: normal;
   padding-left: 0.37rem;
+`
+
+export const NoPreference = styled.span`
+  color: #005c4a;
+  font-family: 'Pretendard Variable';
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  margin-left: -1rem;
 `
 
 export const PreferenceBox = styled.div`

--- a/src/components/MyPage/styled.js
+++ b/src/components/MyPage/styled.js
@@ -252,7 +252,7 @@ export const PreferenceValueBox = styled.div`
   display: flex;
   justify-content: center;
   flex-direction: column;
-  padding-left: 5rem;
+  padding-left: 4rem;
 `
 
 export const Check = styled.img`

--- a/src/components/Preference/ChoosePreference.jsx
+++ b/src/components/Preference/ChoosePreference.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import axios from 'axios'
 import * as S from './styled'
 import Button from './Button'
 import NoticeModal from '../common/NoticeModal'
@@ -35,8 +36,6 @@ import unique from '@/assets/icons/unique.svg'
 import unique_green from '@/assets/icons/unique-green.svg'
 
 const ChoosePreference = () => {
-  const [active, setActive] = useState(false)
-
   const PURPOSE = [
     { key: 'atmosphere', title: '감성/분위기', off: atmosphere, on: atmosphere_green },
     { key: 'study', title: '공부/작업공간', off: study, on: study_green },
@@ -61,6 +60,30 @@ const ChoosePreference = () => {
     { key: 'unique', title: '이색테마/메뉴', off: unique, on: unique_green },
   ]
 
+  const PURPOSE_ENUM = {
+    atmosphere: 'EMOTIONAL_ATMOSPHERE',
+    study: 'STUDY_WORKSPACE',
+    meet: 'CHAT_MEETING',
+    hot: 'HOT_PLACE',
+    event: 'EVENT',
+  }
+
+  const MENU_ENUM = {
+    specialTea: 'SPECIALTY',
+    cake: 'DESSERT',
+    decaf: 'DECAF',
+    seasonMenu: 'SEASON_MENU',
+    brunch: 'BRUNCH',
+  }
+
+  const ETC_ENUM = {
+    brand: 'FRANCHISE',
+    animal: 'PET_FRIENDLY',
+    sun: 'OUTDOOR_TERRACE',
+    eco: 'ECO_LOCAL',
+    unique: 'UNIQUE_THEME',
+  }
+
   const [selected, setSelected] = useState([])
 
   const toggle = (key) =>
@@ -73,6 +96,34 @@ const ChoosePreference = () => {
   const [openModal, setOpenModal] = useState(false)
 
   const navigate = useNavigate()
+
+  const handleSave = () => {
+    const token = localStorage.getItem('accessToken')
+
+    const visitPurposes = selected.filter((k) => PURPOSE_ENUM[k]).map((k) => PURPOSE_ENUM[k])
+
+    const preferredMenus = selected.filter((k) => MENU_ENUM[k]).map((k) => MENU_ENUM[k])
+
+    const extraOptions = selected.filter((k) => ETC_ENUM[k]).map((k) => ETC_ENUM[k])
+
+    const body = { visitPurposes, preferredMenus, extraOptions }
+
+    axios
+      .put('https://tumbloom.store/api/users/me/preferences', body, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      })
+      .then((res) => {
+        console.log(res.data)
+        setOpenModal(true)
+      })
+      .catch((err) => {
+        console.error(err)
+        alert(err?.response?.data?.message ?? '저장에 실패했어요')
+      })
+  }
 
   return (
     <>
@@ -134,7 +185,7 @@ const ChoosePreference = () => {
           </S.BtnContainer>
         </S.CategoryBox>
         <S.SaveBtnContainer>
-          <S.SaveBtn onClick={() => setOpenModal(true)}>저장하기</S.SaveBtn>
+          <S.SaveBtn onClick={handleSave}>저장하기</S.SaveBtn>
         </S.SaveBtnContainer>
       </S.Wrapper>
       {openModal && (
@@ -144,7 +195,7 @@ const ChoosePreference = () => {
           subTitle={'홈에서 AI에게 카페 추천을 받을 수 있어요'}
           btnLeft={'취향수정 '}
           btnRight={'홈으로 가기'}
-          onChangeBtnLeft={setOpenModal}
+          onChangeBtnLeft={() => setOpenModal(false)}
           onChangeBtnRight={() => navigate('/home')}
           open
         />

--- a/src/components/ProfileShare/ProfileCard.jsx
+++ b/src/components/ProfileShare/ProfileCard.jsx
@@ -13,14 +13,6 @@ import cup_icon from '../../assets/icons/cup_icon.svg'
 import tree_icon from '../../assets/icons/tree_icon.svg'
 
 const ProfileCard = ({ userName, tumblerCount, savedWater, savedTree, level }) => {
-  const levelCalculate = (stamp) => {
-    if (stamp <= 4) return 1
-    else if (stamp >= 5 && stamp <= 10) return 2
-    else if (stamp >= 11 && stamp <= 20) return 3
-    else if (stamp >= 21 && stamp <= 40) return 4
-    else if (stamp >= 41) return 5
-  }
-
   const currentLevelName = (level) => {
     if (level === 1) return 'Lv.1 텀블러 뉴비'
     else if (level === 2) return 'Lv.2 텀블러 입문자'
@@ -28,8 +20,6 @@ const ProfileCard = ({ userName, tumblerCount, savedWater, savedTree, level }) =
     else if (level === 4) return 'Lv.4 텀블러 고수'
     else if (level === 5) return 'Lv.5 텀블러 히어로'
   }
-
-  const userLevel = levelCalculate(tumblerCount)
 
   const userLevelName = currentLevelName(level)
 

--- a/src/components/ProfileShare/ProfileCard.jsx
+++ b/src/components/ProfileShare/ProfileCard.jsx
@@ -12,11 +12,7 @@ import tumbler_icon from '../../assets/icons/tumbler_icon.svg'
 import cup_icon from '../../assets/icons/cup_icon.svg'
 import tree_icon from '../../assets/icons/tree_icon.svg'
 
-const ProfileCard = ({ stamp, userName }) => {
-  const s = Number(stamp)
-  const water = (s * 0.55).toFixed(2)
-  const tree = (s * 0.003).toFixed(3)
-
+const ProfileCard = ({ userName, tumblerCount, savedWater, savedTree, level }) => {
   const levelCalculate = (stamp) => {
     if (stamp <= 4) return 1
     else if (stamp >= 5 && stamp <= 10) return 2
@@ -33,28 +29,28 @@ const ProfileCard = ({ stamp, userName }) => {
     else if (level === 5) return 'Lv.5 텀블러 히어로'
   }
 
-  const userLevel = levelCalculate(stamp)
+  const userLevel = levelCalculate(tumblerCount)
 
-  const userLevelName = currentLevelName(userLevel)
+  const userLevelName = currentLevelName(level)
 
   return (
     <S.ProfileCardWrapper>
       <S.TumberIn src={Tumberin} />
       <S.ProfileInfoBox>
-        {userLevel === 1 && <S.ProfileImg src={lv1_img} />}
-        {userLevel === 2 && <S.ProfileImg src={lv2_img} />}
-        {userLevel === 3 && <S.ProfileImg src={lv3_img} />}
-        {userLevel === 4 && <S.ProfileImg src={lv4_img} />}
-        {userLevel === 5 && <S.ProfileImg src={lv5_img} />}
+        {level === 1 && <S.ProfileImg src={lv1_img} />}
+        {level === 2 && <S.ProfileImg src={lv2_img} />}
+        {level === 3 && <S.ProfileImg src={lv3_img} />}
+        {level === 4 && <S.ProfileImg src={lv4_img} />}
+        {level === 5 && <S.ProfileImg src={lv5_img} />}
         <S.NickName>{userName}</S.NickName>
         <S.LevelContainer>
           <S.LevelName>{userLevelName}</S.LevelName>
         </S.LevelContainer>
       </S.ProfileInfoBox>
       <S.MatrixContainer>
-        <MatrixChip icon={tumbler_icon} label='텀블러 사용' value={s} />
-        <MatrixChip icon={cup_icon} label='아낀 물' value={water} />
-        <MatrixChip icon={tree_icon} label='지킨 나무' value={tree} />
+        <MatrixChip icon={tumbler_icon} label='텀블러 사용' value={tumblerCount} />
+        <MatrixChip icon={cup_icon} label='아낀 물' value={savedWater} />
+        <MatrixChip icon={tree_icon} label='지킨 나무' value={savedTree} />
       </S.MatrixContainer>
     </S.ProfileCardWrapper>
   )

--- a/src/components/ProfileShare/ProfileShareBox.jsx
+++ b/src/components/ProfileShare/ProfileShareBox.jsx
@@ -4,7 +4,7 @@ import { saveAs } from 'file-saver'
 import ProfileCard from './ProfileCard'
 import * as S from './styled'
 
-const ProfileShareBox = ({ stamp, userName }) => {
+const ProfileShareBox = ({ userName, tumblerCount, savedWater, savedTree, level }) => {
   const cardRef = useRef(null)
 
   const handleDownload = async () => {
@@ -41,7 +41,13 @@ const ProfileShareBox = ({ stamp, userName }) => {
   return (
     <S.Wrapper>
       <div ref={cardRef}>
-        <ProfileCard stamp={stamp} userName={userName} />
+        <ProfileCard
+          userName={userName}
+          tumblerCount={tumblerCount}
+          savedWater={savedWater}
+          savedTree={savedTree}
+          level={level}
+        />
       </div>
       <S.ImgBtn onClick={handleDownload}>이미지 다운받기</S.ImgBtn>
     </S.Wrapper>

--- a/src/components/common/CafeListCard.Styled.js
+++ b/src/components/common/CafeListCard.Styled.js
@@ -106,4 +106,5 @@ export const CafeImg = styled.img`
   height: 6.8125rem;
   flex-shrink: 0;
   border-radius: 0.3125rem;
+  object-fit: cover;
 `

--- a/src/pages/Coupon.jsx
+++ b/src/pages/Coupon.jsx
@@ -1,16 +1,18 @@
 import React, { useState } from 'react'
+import { useLocation } from 'react-router-dom'
 import CouponHeader from '@/components/Coupon/CouponHeader'
 import Footer from '@/components/common/Footer'
 import CouponChange from '@/components/Coupon/CouponChange'
 import MyCoupon from '@/components/Coupon/MyCoupon'
 
 const Coupon = () => {
-  const [tab, setTab] = useState('exchange')
+  const location = useLocation()
+  const [tab, setTab] = useState(location.state?.tab || 'exchange')
 
   return (
     <>
       <CouponHeader tab={tab} onChangeTab={setTab} />
-      {tab === 'exchange' ? <CouponChange /> : <MyCoupon coupon={5} />}
+      {tab === 'exchange' ? <CouponChange /> : <MyCoupon />}
 
       <Footer />
     </>

--- a/src/pages/FavoriteCafe.jsx
+++ b/src/pages/FavoriteCafe.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import CafeListCard from '@/components/common/CafeListCard'
 import Header from '@/components/common/Header'
 import FavoriteCafeList from '@/components/FavoriteCafeList/FavoriteCafeList'
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import axios from 'axios'
 import HeaderArea from '@/components/Home/HeaderArea'
-// import MatrixBar from '@/components/Home/MatrixBar'
 import StampArea from '@/components/Home/StampArea'
 import CafeRecommend from '@/components/Home/CafeRecommend'
 import Footer from '@/components/common/Footer'

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -4,7 +4,6 @@ import Footer from '@/components/common/Footer'
 import ProfileContent from '@/components/MyPage/ProfileContent'
 import ProfileInfo from '@/components/MyPage/ProfileInfo'
 import LevelModal from '@/components/MyPage/LevelModal'
-import { NickName } from '@/components/ProfileShare/styled'
 
 const MyPage = () => {
   const [info, setInfo] = useState(false)
@@ -39,21 +38,6 @@ const MyPage = () => {
         console.log(err)
       })
   }, [])
-
-  const stamp = 10
-  const usedCoupon = 2
-  const availableCoupon = 3
-  const favoriteCafe = 2
-
-  const levelCalculate = (stamp) => {
-    if (stamp <= 4) return 1
-    else if (stamp >= 5 && stamp <= 10) return 2
-    else if (stamp >= 11 && stamp <= 20) return 3
-    else if (stamp >= 21 && stamp <= 40) return 4
-    else if (stamp >= 41) return 5
-  }
-
-  const currentLevel = levelCalculate(stamp)
 
   return (
     <div style={{ backgroundColor: '#F6FCFB' }}>

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -10,7 +10,7 @@ const MyPage = () => {
   const [info, setInfo] = useState(false)
 
   const [userName, setUserName] = useState('')
-  const [level, setLevel] = useState('')
+  const [level, setLevel] = useState(0)
   const [tumblerCount, setTumblerCount] = useState(0)
   const [issuedCoupons, setIssuedCoupons] = useState(0)
   const [availableCoupons, setAvailableCoupons] = useState(0)
@@ -35,7 +35,10 @@ const MyPage = () => {
         setTopPreferences(res.data.data.topPreferences)
         setStepsLeft(res.data.data.stepsLeft)
       })
-  })
+      .catch((err) => {
+        console.log(err)
+      })
+  }, [])
 
   const stamp = 10
   const usedCoupon = 2

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,11 +1,41 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
+import axios from 'axios'
 import Footer from '@/components/common/Footer'
 import ProfileContent from '@/components/MyPage/ProfileContent'
 import ProfileInfo from '@/components/MyPage/ProfileInfo'
 import LevelModal from '@/components/MyPage/LevelModal'
+import { NickName } from '@/components/ProfileShare/styled'
 
 const MyPage = () => {
   const [info, setInfo] = useState(false)
+
+  const [userName, setUserName] = useState('')
+  const [level, setLevel] = useState('')
+  const [tumblerCount, setTumblerCount] = useState(0)
+  const [issuedCoupons, setIssuedCoupons] = useState(0)
+  const [availableCoupons, setAvailableCoupons] = useState(0)
+  const [favoriteCafes, setFavoriteCafes] = useState(0)
+  const [topPreferences, setTopPreferences] = useState([])
+  const [stepsLeft, setStepsLeft] = useState(0)
+
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken')
+
+    axios
+      .get('https://tumbloom.store/api/users/me/mypage', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then((res) => {
+        setUserName(res.data.data.nickname)
+        setLevel(res.data.data.level)
+        setTumblerCount(res.data.data.tumblerCount)
+        setIssuedCoupons(res.data.data.issuedCoupons)
+        setAvailableCoupons(res.data.data.availableCoupons)
+        setFavoriteCafes(res.data.data.favoriteCafes)
+        setTopPreferences(res.data.data.topPreferences)
+        setStepsLeft(res.data.data.stepsLeft)
+      })
+  })
 
   const stamp = 10
   const usedCoupon = 2
@@ -24,12 +54,19 @@ const MyPage = () => {
 
   return (
     <div style={{ backgroundColor: '#F6FCFB' }}>
-      <ProfileContent onChangeInfo={setInfo} stamp={stamp} level={currentLevel} />
+      <ProfileContent
+        onChangeInfo={setInfo}
+        nickName={userName}
+        level={level}
+        stepsLeft={stepsLeft}
+        tumblerCount={tumblerCount}
+      />
       <ProfileInfo
-        stamp={stamp}
-        usedCoupon={usedCoupon}
-        availableCoupon={availableCoupon}
-        favoriteCafe={favoriteCafe}
+        tumblerCount={tumblerCount}
+        issuedCoupons={issuedCoupons}
+        availableCoupons={availableCoupons}
+        favoriteCafes={favoriteCafes}
+        topPreferences={topPreferences}
       />
       <Footer />
       {info && <LevelModal onChangeInfo={setInfo} />}

--- a/src/pages/ProfileShare.jsx
+++ b/src/pages/ProfileShare.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import axios from 'axios'
 import Header from '@/components/common/Header'
-import ProfileCard from '@/components/ProfileShare/ProfileCard'
 import ProfileShareBox from '@/components/ProfileShare/ProfileShareBox'
 
 const ProfileShare = () => {

--- a/src/pages/ProfileShare.jsx
+++ b/src/pages/ProfileShare.jsx
@@ -1,13 +1,60 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import axios from 'axios'
 import Header from '@/components/common/Header'
 import ProfileCard from '@/components/ProfileShare/ProfileCard'
 import ProfileShareBox from '@/components/ProfileShare/ProfileShareBox'
 
 const ProfileShare = () => {
+  const [userName, setuserName] = useState('')
+  const [tumblerCount, setTumblerCount] = useState('')
+  const [savedWater, setSavedWater] = useState('')
+  const [savedTree, setSavedTree] = useState('')
+  const [level, setLevel] = useState(0)
+
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken')
+
+    axios
+      .get('https://tumbloom.store/api/users/me/home', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then((res) => {
+        console.log(res.data)
+        setuserName(res.data.data.welcomeStatus.nickname)
+        setTumblerCount(res.data.data.welcomeStatus.tumblerCount)
+        setSavedWater(res.data.data.welcomeStatus.savedWater)
+        setSavedTree(res.data.data.welcomeStatus.savedTree)
+      })
+      .catch((err) => {
+        console.log(err)
+      })
+  }, [])
+
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken')
+
+    axios
+      .get('https://tumbloom.store/api/users/me/mypage', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then((res) => {
+        setLevel(res.data.data.level)
+      })
+      .catch((err) => {
+        console.log(err)
+      })
+  }, [])
+
   return (
     <div>
       <Header title={'프로필 공유'} />
-      <ProfileShareBox stamp={41} userName={'텀블러91'} />
+      <ProfileShareBox
+        userName={userName}
+        tumblerCount={tumblerCount}
+        savedWater={savedWater}
+        savedTree={savedTree}
+        level={level}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
  #59 

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
1. 마이페이지에 있는 모든 데이터 연동
2. 프로필 공유 페이지 데이터 연동
3. 취향 선택 연동 
4. 취향 선택 3개 불러와서 마이페이지에 보여주기

### 남은 해야할 일들
1. 마이페이지에서 데이터 받아와서 상태바 너비 props로 넘겨주기
2. 즐겨찾는 카페 데이터 연동 


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
1. pull 받으니까 CafeListCard.jsx 부분에서 image props 안넣어줬길래 목데이터에 이미지 주소 추가 및 카페 이미지 비율 안찌그러지게 수정해뒀습니다!

## 📷 ScreenShot
<!— UI 변경이 있다면 스크린샷 첨부해주세요. —>

<img width="2559" height="1599" alt="image" src="https://github.com/user-attachments/assets/8d61e599-c3ee-4676-a552-28feb6dee8b4" />

<img width="2559" height="1599" alt="image" src="https://github.com/user-attachments/assets/8b2cba8c-1bbd-4f77-be39-b96c5e51fe48" />

<img width="2559" height="1599" alt="image" src="https://github.com/user-attachments/assets/9dee610c-e751-4f5e-83a5-f0a3f9e873bd" />


<img width="2559" height="1599" alt="image" src="https://github.com/user-attachments/assets/583172b0-6cf3-412e-9e59-63da4e3ed1df" />
