### PR TITLE
Feat/#74/로그인 실패 안내 텍스트 띄우기

### DIFF
--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -53,12 +53,22 @@ const GoToRegisterBtn = styled.span`
   cursor: pointer;
 `
 
+const LoginErrorText = styled.span`
+  color: #f54d4dff;
+  text-align: center;
+  font-family: Inter;
+  font-size: 0.9375rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  padding: 0.94rem 0 0 0;
+`
+
 function Login() {
   const [email, setEmail] = useState('')
-
   const [password, setPassword] = useState('')
-
   const [btnColor, setBtnColor] = useState(false)
+  const [error, setError] = useState('')
 
   const navigate = useNavigate()
 
@@ -77,12 +87,14 @@ function Login() {
   const handleLogin = () => {
     if (btnColor) {
       // 로그인 로직 추가할 예정
-      navigate('/')
+
+      navigate('/home')
     }
   }
 
   const onLoginHandler = async () => {
     try {
+      setError('')
       const response = await axios.post(
         `https://tumbloom.store/api/auth/login`,
         { email, password },
@@ -104,7 +116,14 @@ function Login() {
       setPassword('')
       handleLogin()
     } catch (error) {
-      console.log(error.response.data.message)
+      const status = error.response?.status
+      if (status === 404) {
+        setError('등록되지 않은 이메일입니다.')
+      } else if (status === 401) {
+        setError('비밀번호가 일치하지 않습니다.')
+      } else {
+        setError('로그인에 실패했습니다. 다시 시도하세요')
+      }
     }
   }
 
@@ -129,8 +148,10 @@ function Login() {
           텀블러인 계정이 없나요?{' '}
           <GoToRegisterBtn onClick={goToRegister}>회원가입하기</GoToRegisterBtn>
         </Desc>
+        {error && <LoginErrorText>{error}</LoginErrorText>}
       </LoginContainer>
     </>
   )
 }
+
 export default Login

--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -55,7 +55,6 @@ const GoToRegisterBtn = styled.span`
 
 const LoginErrorText = styled.span`
   color: #f54d4dff;
-  text-align: center;
   font-family: Inter;
   font-size: 0.9375rem;
   font-style: normal;
@@ -118,11 +117,11 @@ function Login() {
     } catch (error) {
       const status = error.response?.status
       if (status === 404) {
-        setError('등록되지 않은 이메일입니다.')
+        setError('등록되지 않은 이메일입니다')
       } else if (status === 401) {
-        setError('비밀번호가 일치하지 않습니다.')
+        setError('비밀번호가 일치하지 않습니다')
       } else {
-        setError('로그인에 실패했습니다. 다시 시도하세요')
+        setError('로그인에 실패했습니다')
       }
     }
   }
@@ -143,12 +142,12 @@ function Login() {
           value={password}
           type='password'
         />
+        {error && <LoginErrorText>{error}</LoginErrorText>}
         <RegisterBtn btnName='로그인' onClick={onLoginHandler} disabled={!btnColor} />
         <Desc>
           텀블러인 계정이 없나요?{' '}
           <GoToRegisterBtn onClick={goToRegister}>회원가입하기</GoToRegisterBtn>
         </Desc>
-        {error && <LoginErrorText>{error}</LoginErrorText>}
       </LoginContainer>
     </>
   )


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
  #74 

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
- 로그인에 실패해도 따로 에러 메시지가 뜨지 않는 부분 수정했습니다!
- `⚠️401`  비밀번호가 일치하지 않습니다 
- `⚠️404` 등록되지 않은 이메일입니다 
- `⚠️그 외 에러` 로그인에 실패했습니다

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<img width="347" height="361" alt="image" src="https://github.com/user-attachments/assets/5c7589c4-cc08-4e5e-be1c-28d1b9b47448" />
