### PR TITLE
Style/#83/스탬프 적립하기 레이아웃 조정 및 카페 이미지 넘겨주기

### DIFF
--- a/src/components/common/CafeListCard.jsx
+++ b/src/components/common/CafeListCard.jsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom'
 function CafeListCard({ name, loc, time, image }) {
   const navigate = useNavigate()
   const goToGetStamp = () => {
-    navigate(`/stamp`, { state: { cafeName: name } })
+    navigate(`/stamp`, { state: { cafeName: name, cafeImg: image } })
   }
   return (
     <S.Container>

--- a/src/components/getStamp/StampAccess.Styled.js
+++ b/src/components/getStamp/StampAccess.Styled.js
@@ -39,7 +39,7 @@ export const TextArea = styled.div`
   position: absolute;
   align-items: center;
   justify-content: flex-start;
-  padding-top: 11.56rem;
+  padding-top: 13rem;
 `
 
 export const Title = styled.span`
@@ -69,10 +69,12 @@ export const Desc = styled.span`
   font-style: normal;
   font-weight: 400;
   line-height: 130%;
+  padding-top: 0.3rem;
 `
 export const AccessCodeBox = styled.div`
   display: flex;
   flex-direction: column;
+  padding-top: 3rem;
 `
 export const AccessCodeHeader = styled.span`
   color: #000;
@@ -82,7 +84,7 @@ export const AccessCodeHeader = styled.span`
   font-style: normal;
   font-weight: 600;
   line-height: normal;
-  padding: 7.63rem 0 0.62rem;
+  padding: 7.63rem 0 1.5rem;
 `
 export const InputField = styled.div`
   display: flex;

--- a/src/components/getStamp/StampAccess.jsx
+++ b/src/components/getStamp/StampAccess.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import CafeImg from '@/assets/images/get-stamp-cafe.png'
 import Header from '@/components/common/Header'
 import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
@@ -12,6 +11,7 @@ function StampAccess() {
   const [showStampBg, setShowStampBg] = useState(false)
   const location = useLocation()
   const cafeName = location.state?.cafeName || ''
+  const cafeImg = location.state?.cafeImg || ''
   const navigate = useNavigate()
   const code = '12345'
 
@@ -30,17 +30,17 @@ function StampAccess() {
     if (isError) setIsError(false)
   }
 
-  const goToQr = () => {
+  const goToPrev = () => {
     navigate(-1)
   }
 
   return (
     <>
       {showStampBg && <GetStamp />}
-      <Header title='스탬프 적립하기' onLeftClick={goToQr} />
+      <Header title='스탬프 적립하기' onLeftClick={goToPrev} />
       <S.Container>
         <S.TopImage>
-          <S.BgImg src={CafeImg} />
+          <S.BgImg src={cafeImg} />
           <S.ImgEffect />
           <S.TextArea>
             <S.Title>


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
#83 
  

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
- 스탬프 적립하기 페이지 레이아웃 조정
- 지도 - 목록보기에서 카페 리스트 스탬프 적립하기 버튼 클릭
 ➡️ 카페에 맞는 이미지 적립하기 페이지에 뜨도록 수정


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
전체 높이에 맞게 레이아웃 조정했는데, 혹시 더 조정이 필요할 것 같다면 말씀해 주세요!


## 📷 ScreenShot
<img width="381" height="633" alt="image" src="https://github.com/user-attachments/assets/eb008015-0584-4c57-8eeb-6ad187b5837a" />
