### PR TITLE
Design/#156/모바일 레이아웃 조정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,8 @@ import SignUp from './pages/SignUp'
 
 function App() {
   return (
-    <div className='phone-frame'>
+    // <div className='phone-frame'>
+    <div style={{ width: '100%' }}>
       <Outlet />
     </div>
   )

--- a/src/components/CafeList/CafeList.Styled.js
+++ b/src/components/CafeList/CafeList.Styled.js
@@ -2,20 +2,20 @@ import styled from 'styled-components'
 
 export const ScrollArea = styled.div`
   display: flex;
-  width: 24.5625rem;
+  /* width: 24.5625rem; */
   flex-direction: column;
   /* height: 55rem; */
   background: #fff;
-  padding-top: 3.5rem;
+  /* padding-top: 3.5rem; */
 `
 
 export const Wrapper = styled.div`
-  width: 24.5625rem;
+  /* width: 24.5625rem; */
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  border-top: 1px solid #d9d9d9;
+  /* border-top: 1px solid #d9d9d9; */
   flex: 1;
   min-height: 0;
   /* overflow-y: auto; */

--- a/src/components/Coupon/styled.js
+++ b/src/components/Coupon/styled.js
@@ -3,10 +3,11 @@ import search from '@/assets/icons/search.svg'
 
 export const HeaderContainer = styled.div`
   display: flex;
-  width: 24.5625rem;
+  /* width: 24.5625rem; */
+  width: 100%;
   height: 3.5rem;
   box-sizing: border-box;
-  position: fixed;
+  position: sticky;
   top: 0;
   z-index: 1000;
   padding-top: 0;
@@ -17,7 +18,8 @@ export const HeaderContainer = styled.div`
 
 export const CouponChangeTap = styled.div`
   display: flex;
-  width: 12.28125rem;
+  /* width: 12.28125rem; */
+  width: 50%;
   height: 3.4rem;
   justify-content: center;
   align-items: center;
@@ -27,7 +29,8 @@ export const CouponChangeTap = styled.div`
 
 export const MyCouponTap = styled.div`
   display: flex;
-  width: 12.28125rem;
+  /* width: 12.28125rem; */
+  width: 50%;
   height: 3.4rem;
   justify-content: center;
   align-items: center;
@@ -49,7 +52,7 @@ export const Wrapper = styled.div`
   /* height: 43.5rem; */
   /* flex: 1; */
   /* width: 24.5625rem; */
-  padding-top: 3.5rem;
+  /* padding-top: 3.5rem; */
   padding-bottom: 6rem;
 `
 
@@ -259,7 +262,7 @@ export const MyCouponWrapper = styled.div`
   gap: 1.4rem;
   overflow-y: auto;
   /* height: 42rem; */
-  padding-top: 3.5rem;
+  /* padding-top: 3.5rem; */
   padding-bottom: 6rem;
 `
 

--- a/src/components/Home/styled.js
+++ b/src/components/Home/styled.js
@@ -312,7 +312,10 @@ export const InfoBackground = styled.div`
   display: flex;
   position: absolute;
   z-index: 4;
-  width: 24.5625rem;
+  width: 100%;
+  max-width: 440px;
+  margin: 0 auto;
+  /* width: 24.5625rem; */
   /* height: 53.25rem; */
   background-color: rgba(0, 20, 16, 0.75);
   inset: 0;

--- a/src/components/Home/styled.js
+++ b/src/components/Home/styled.js
@@ -9,7 +9,8 @@ export const Wrapper = styled.div`
   background-size: 100% auto;
   background-repeat: no-repeat;
   width: 100%;
-  min-height: 17.5rem;
+  min-height: 310px;
+  /* padding-bottom: 90px; */
 `
 
 export const GreetingWrapper = styled.div`

--- a/src/components/MyPage/styled.js
+++ b/src/components/MyPage/styled.js
@@ -138,6 +138,7 @@ export const ContentContainer = styled.div`
   gap: 1.5rem;
   align-items: center;
   padding-top: 1rem;
+  padding-bottom: 6rem;
 `
 
 export const CurrentCountBox = styled.div`

--- a/src/components/MyPage/styled.js
+++ b/src/components/MyPage/styled.js
@@ -311,11 +311,13 @@ export const BoxValue = styled.p`
 //LevelModal.jsx
 
 export const LevelModalBackground = styled.div`
-  max-width: 100%;
+  max-width: 440px;
+  width: 100%;
+  margin: 0 auto;
   display: flex;
   position: absolute;
   z-index: 4;
-  width: 24.5625rem;
+  /* width: 24.5625rem; */
   background-color: rgba(0, 20, 16, 0.75);
   inset: 0;
   align-items: center;

--- a/src/components/Preference/styled.js
+++ b/src/components/Preference/styled.js
@@ -35,7 +35,7 @@ export const Wrapper = styled.div`
   flex-direction: column;
   align-items: center;
   border-top: 1px solid #d9d9d9;
-  padding-top: 3.5rem;
+  /* padding-top: 3.5rem; */
 `
 
 export const TitleBox = styled.div`

--- a/src/components/common/Footer.Styled.js
+++ b/src/components/common/Footer.Styled.js
@@ -10,7 +10,9 @@ export const FooterBox = styled.div`
   z-index: 2;
   justify-content: center;
   align-items: center;
-  width: 24.5625rem;
+  /* width: 24.5625rem; */
+  width: 100%;
+  max-width: 440px;
   transform: translateX(-50%);
   height: 5.6875rem;
   flex-shrink: 0;

--- a/src/components/common/Header.Styled.js
+++ b/src/components/common/Header.Styled.js
@@ -3,10 +3,11 @@ import styled from 'styled-components'
 export const HeaderBox = styled.div`
   display: grid;
   grid-template-columns: 3.5rem 1fr 3.5rem;
-  width: 24.5625rem;
+  /* width: 24.5625rem; */
+  width: 100%;
   height: 3.5rem;
   box-sizing: border-box;
-  position: fixed;
+  position: sticky;
   top: 0;
   z-index: 10;
   padding-top: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -7,9 +7,14 @@ body,
 
 #root {
   min-height: 100dvh;
+  max-width: 440px;
+  margin-left: auto;
+  margin-right: auto;
   display: flex;
   justify-content: center;
   background: #fff;
+  box-shadow: 0 0 0.625rem rgb(184, 181, 181);
+  overflow-y: auto;
 }
 
 @font-face {
@@ -27,7 +32,7 @@ body,
   font-style: normal;
 }
 
-.phone-frame {
+/* .phone-frame {
   width: 24.5625rem;
   max-width: 100%;
   position: relative;
@@ -37,4 +42,4 @@ body,
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
   padding-bottom: env(safe-area-inset-bottom);
-}
+} */

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -41,7 +41,7 @@ const MyPage = () => {
   }, [])
 
   return (
-    <div style={{ backgroundColor: '#F6FCFB', padding: '0 0 6rem 0' }}>
+    <div style={{ backgroundColor: '#F6FCFB', padding: '0 0 0 0', height: '100%' }}>
       <ProfileContent
         onChangeInfo={setInfo}
         nickName={userName}


### PR DESCRIPTION
## 📌 Related Issue
#156 
  

## ✨ Work Description
모바일 레이아웃 조정
1. 폰프레임 삭제
2. root 너비 최대 440px로 고정
3. 다른 페이지 너비 조정

### 남은 해야할 일들
1. 페이지, 컴포넌트 너비 및 레이아웃 조정 필요


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!— UI 변경이 있다면 스크린샷 첨부해주세요. —>
<img width="2559" height="1599" alt="image" src="https://github.com/user-attachments/assets/2547e57c-ec43-4f39-80ca-b7d1d59e5117" />

