### PR TITLE
Chore/#163/카페명 overflow 처리

### DIFF
--- a/src/components/Coupon/styled.js
+++ b/src/components/Coupon/styled.js
@@ -199,6 +199,10 @@ export const CafeName = styled.span`
   line-height: normal;
   margin: 0;
   padding: 0.3rem 0 0.5rem 1.38rem;
+  width: 13rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `
 
 export const CafeDiscount = styled.span`

--- a/src/components/getStamp/StampAccess.Styled.js
+++ b/src/components/getStamp/StampAccess.Styled.js
@@ -55,13 +55,20 @@ export const Title = styled.span`
   text-align: center;
 `
 export const CafeName = styled.span`
+  vertical-align: bottom;
+  padding-bottom: 0.3rem;
+  display: inline-block;
+  max-width: 23rem;
   color: #25af94;
   text-align: center;
   font-family: 'Pretendard Variable';
   font-size: 1.75rem;
   font-style: normal;
   font-weight: 700;
-  line-height: 130%; /* 2.275rem */
+  line-height: 90%; /* 2.275rem */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `
 export const Desc = styled.span`
   color: #767676;

--- a/src/pages/StampAccess.jsx
+++ b/src/pages/StampAccess.jsx
@@ -90,7 +90,8 @@ function StampAccess() {
           <S.ImgEffect />
           <S.TextArea>
             <S.Title>
-              <S.CafeName>{cafeName}</S.CafeName> 에서 <br /> 텀블러 테이크아웃할게요
+              <S.CafeName>{cafeName}</S.CafeName>
+              에서 <br /> 텀블러 테이크아웃할게요
             </S.Title>
             <S.Desc>
               음료 받을 때 직원에게 화면을 보여주고 <br />


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
#163 
  

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
**카페명이 길어질 때 레이아웃이 깨지지 않도록 말줄임(…) 처리 적용**

```
✅ 카페별 스탬프 적립하기 페이지 수정
✅ 쿠폰 페이지 수정
```
```
  vertical-align: bottom;
  display: inline-block;
  max-width: 23rem;
  padding-bottom: 0.3rem;
  overflow: hidden;
  text-overflow: ellipsis;
  white-space: nowrap;
```
`span`은 inline 요소라서 width 직접 줄 수 없는 문제 발생 💥
-> 폭(width)을 정해두고 … 처리를 하기 위해 
`display: inline-block` 으로 바꿔서 박스처럼 만들었어요!

1️⃣ display: inline-block (-> 사용하게 되면 글자 수직 정렬이 틀어지기 때문에 ⬇️)
2️⃣ vertical-align: bottom으로 줄 하단에 맞춤
3️⃣ 필요한 만큼 padding-bottom으로 조정

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
현재 더미데이터 카페명 중 가장 긴 
`오가다 대한무역투자진흥공사점` 기준으로 폭을 설정해 두었습니다!

## 📷 ScreenShot
<!— UI 변경이 있다면 스크린샷 첨부해주세요. —>
