### PR TITLE
Feat/#164/Refresh Token 기반 자동 로그인 구현

### DIFF
--- a/src/apis/api.js
+++ b/src/apis/api.js
@@ -1,0 +1,37 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  withCredentials: true,
+  headers: { 'Content-Type': 'application/json' },
+})
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('accessToken')
+  if (token) config.headers.Authorization = `Bearer ${token}`
+  return config
+})
+
+api.interceptors.response.use(
+  (res) => res,
+  async (err) => {
+    if (err.response?.status === 401) {
+      try {
+        const { data } = await axios.get(`/api/auth/refresh`, {
+          withCredentials: true,
+          headers: { 'Content-Type': 'application/json' },
+        })
+        localStorage.setItem('accessToken', data.accessToken)
+
+        err.config.headers.Authorization = `Bearer ${data.accessToken}`
+        return api(err.config)
+      } catch {
+        localStorage.removeItem('accessToken')
+        window.location.href = '/login'
+      }
+    }
+    return Promise.reject(err)
+  },
+)
+
+export default api

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router-dom'
 import visibleIcon from '@/assets/icons/pwd-visible.svg'
 import invisibleIcon from '@/assets/icons/pwd-invisible.svg'
 import PwdInputField from '@/components/common/PwdInputField'
-import axios from 'axios'
+import api from '@/apis/api'
 
 const LoginContainer = styled.div`
   display: flex;
@@ -64,7 +64,6 @@ const LoginErrorText = styled.span`
 `
 
 function Login() {
-  const baseURL = import.meta.env.VITE_API_BASE_URL
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [btnColor, setBtnColor] = useState(false)
@@ -95,13 +94,7 @@ function Login() {
   const onLoginHandler = async () => {
     try {
       setError('')
-      const response = await axios.post(
-        `${baseURL}api/auth/login`,
-        { email, password },
-        { headers: { 'Content-Type': 'application/json' } },
-      )
-
-      console.log('login response.data =', response.data)
+      const response = await api.post(`/api/auth/login`, { email, password })
 
       const accessToken = response.data?.accessToken ?? response.data?.data?.accessToken
       if (!accessToken) {
@@ -125,10 +118,6 @@ function Login() {
     }
   }
 
-  const goToRegister = () => {
-    navigate('/signup')
-  }
-
   return (
     <>
       <LoginContainer>
@@ -145,7 +134,7 @@ function Login() {
         <RegisterBtn btnName='로그인' onClick={onLoginHandler} disabled={!btnColor} />
         <Desc>
           텀블러인 계정이 없나요?{' '}
-          <GoToRegisterBtn onClick={goToRegister}>회원가입하기</GoToRegisterBtn>
+          <GoToRegisterBtn onClick={() => navigate(`/signup`)}>회원가입하기</GoToRegisterBtn>
         </Desc>
       </LoginContainer>
     </>


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
#164 
  

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
1️⃣ Axios 인스턴스(api.js) 생성

- withCredentials: true 옵션과 baseURL 적용한 공통 API 모듈 생성


2️⃣ Access Token 만료 처리

- API 응답이 401일 때 /api/auth/refresh 호출 -> 새 Access Token을 발급받도록 구현
- 새로 받은 토큰을 localStorage에 저장 & 원래 요청 재시도

3️⃣ 로그인 페이지 리팩토링

- 기존 fetch/axios 직접 호출 제거 -> api 인스턴스 사용하도록 수정
- 로그인 성공 시 Access Token을 저장하고 홈 화면으로 이동


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->

Refresh Token을 HttpOnly 쿠키로 관리하고 있는데, 로컬에서는 브라우저가 쿠키를 저장하지 않는 문제가 있어 자동 로그인 관련된 확인은 배포된 앱에서 확인해야 합니다!

